### PR TITLE
fix: Build and Publish Lambda Layer

### DIFF
--- a/.github/workflows/CD_publish_layer_zip.yml
+++ b/.github/workflows/CD_publish_layer_zip.yml
@@ -32,37 +32,24 @@ jobs:
           > lambda_layer_requirements.txt
 
       - name: Create Lambda Layer directory
+        working-directory: src
         run: mkdir -p lambda_layer/python
 
       - name: Install Dependencies for Layer
+        working-directory: src
         run: >
           uv pip install 
           --target=lambda_layer/python 
           -r lambda_layer_requirements.txt
 
       - name: Zip Lambda Layer
-        working-directory: src/src
+        working-directory: src
         run: zip -r lambda_layer.zip python
 
       - name: Upload Lambda Layer as GitHub Artifact
         uses: actions/upload-artifact@v4
         with:
           name: hermes-zip-lambda-layer
-          path: lambda_layer/lambda_layer.zip
+          path: src/lambda_layer/lambda_layer.zip
           overwrite: true
           if-no-files-found: error
-
-      - name: Create GitHub Release with Artifact Link
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: layer-v${{ github.run_number }}
-          release_name: Hermes Lambda Layer v${{ github.run_number }}
-          draft: false
-          prerelease: false
-          body: |
-            Lambda Layer containing dependencies for Hermes.
-            Download the artifact from the Actions tab or the release below.
-          artifacts: lambda_layer/lambda_layer.zip


### PR DESCRIPTION
- set `src` as working-directory in all steps
- stop publishing a release