### PR TITLE
fix: rename artifact

### DIFF
--- a/.github/workflows/CD_publish_layer_zip.yml
+++ b/.github/workflows/CD_publish_layer_zip.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload Lambda Layer as GitHub Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: hermes-zip-lambda-layer
+          name: python
           path: src/lambda_layer/python
           overwrite: true
           if-no-files-found: error


### PR DESCRIPTION
- the root folder name becomes the name of the artifact, so we are forced to name it `python`